### PR TITLE
home.html Reverse order of posts on homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,7 +5,7 @@
           <article class="archive-wrap">
               <ol class="post-list">
                  <lh><h2><span class="bb">{{ page.title }}</span></h2></lh>
-                  {% for post in site.posts %}
+                  {% for post in site.posts reversed %}
                   <li>
                     <div class="deets" itemscope itemtype="http://schema.org/BlogPosting" itemprop="blogPost">
                         <h1><a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a></h1>


### PR DESCRIPTION
If you update the homepage template like this, the blog posts will be listed in 'reversed' order, ie, first post first, which I think makes more sense for this site :) 
